### PR TITLE
Update vidle.ts

### DIFF
--- a/src/components/vidle.ts
+++ b/src/components/vidle.ts
@@ -111,6 +111,7 @@ const Vidle = Vue.extend({
       this.counter = window.setInterval(this.countdown, 1000)
     },
     clearTimer() {
+      this.$emit("clearTimer")
       clearInterval(this.timer)
       clearInterval(this.counter)
       this.setDisplay()


### PR DESCRIPTION
We need to know when the timer was cleared (something happened).

The problem is, when the page is closed, the idle timer is destroyed, so when the page reopens, we dont know how long its been since they've been active. There are other use cases for this too.